### PR TITLE
fix game completion overlay size

### DIFF
--- a/src/components/GameBoard/GameBoard.css
+++ b/src/components/GameBoard/GameBoard.css
@@ -3,6 +3,7 @@
   @apply h-side;
   @apply my-0;
   @apply mx-auto;
+  @apply z-0;
 
   @apply bg-transparent;
   @apply relative;
@@ -10,17 +11,17 @@
   &__success-overlay {
     @apply absolute;
     @apply top-0;
-    @apply w-full;
-    @apply h-full;
+    @apply w-side;
+    @apply h-side;
+    @apply z-10;
     @apply flex;
     @apply justify-center;
     @apply items-center;
     @apply text-primary-main;
     @apply font-bold;
     @apply text-3xl;
-  }
-
-  &--solved {
-    filter: blur(4px) grayscale(80%) brightness(30%);
+    @apply bg-black;
+    backdrop-filter: blur(4px);
+    @apply bg-opacity-75;
   }
 }

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -1,4 +1,3 @@
-import classnames from "classnames"
 import {
   createBoardFetchAction,
   createBoardSetUserPressedAction,
@@ -70,14 +69,9 @@ const GameBoard: FC<GameBoardProps> = ({
     }
   }, [pressedKey])
 
-  const _classNames = classnames("game-board", {
-    "game-board--solved":
-      validationStatus === ServerBoardValidationStatus.SOLVED,
-  })
-
   return (
     <>
-      <div className={_classNames}>
+      <div className="game-board">
         <BoardLines />
         <ParsedBoard
           board={board}
@@ -85,10 +79,10 @@ const GameBoard: FC<GameBoardProps> = ({
           highlightedNumber={highlightedNumber}
           pencilMarkBoard={pencilMarkBoard}
         />
+        {validationStatus === ServerBoardValidationStatus.SOLVED && (
+          <div className="game-board__success-overlay">Awesome!</div>
+        )}
       </div>
-      {validationStatus === ServerBoardValidationStatus.SOLVED && (
-        <div className="game-board__success-overlay">Awesome!</div>
-      )}
     </>
   )
 }


### PR DESCRIPTION
- Change/add hierarchy of board and overlay of board upon completion
- Add CSS styling to the overlay to match board and mimic previous overlay filters
- TLDR only the overlay comes up after beating the game and have it match the board size
<img width="1440" alt="fix game completion overlay size #14" src="https://user-images.githubusercontent.com/65873888/88352113-42b39600-cd1e-11ea-8b65-8480d24812af.png">