### PR TITLE
Give pause state tracking from pieces to the board

### DIFF
--- a/src/components/GameBoard/GameBoard.css
+++ b/src/components/GameBoard/GameBoard.css
@@ -20,8 +20,6 @@
     @apply text-primary-main;
     @apply font-bold;
     @apply text-3xl;
-    backdrop-filter: blur(8px);
-    @apply bg-opacity-75;
   }
 
   &__success-overlay {
@@ -40,4 +38,24 @@
     backdrop-filter: blur(4px);
     @apply bg-opacity-75;
   }
+}
+
+.empty-board {
+  @apply absolute;
+  @apply top-0;
+  @apply bg-gray-800;
+  @apply h-full;
+  @apply w-full;
+  @apply grid;
+  @apply z-10;
+
+  grid-template-columns: repeat(9, 1fr);
+  grid-template-rows: repeat(9, 1fr);
+  gap: calc(var(--side) * var(--thickness));
+}
+
+.empty-piece {
+  @apply w-full;
+  @apply h-full;
+  @apply bg-gray-900;
 }

--- a/src/components/GameBoard/GameBoard.css
+++ b/src/components/GameBoard/GameBoard.css
@@ -7,6 +7,22 @@
 
   @apply bg-transparent;
   @apply relative;
+  
+  &__paused-overlay {
+    @apply absolute;
+    @apply top-0;
+    @apply w-side;
+    @apply h-side;
+    @apply z-10;
+    @apply flex;
+    @apply justify-center;
+    @apply items-center;
+    @apply text-primary-main;
+    @apply font-bold;
+    @apply text-3xl;
+    backdrop-filter: blur(8px);
+    @apply bg-opacity-75;
+  }
 
   &__success-overlay {
     @apply absolute;

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -83,7 +83,7 @@ const GameBoard: FC<GameBoardProps> = ({
           highlightedNumber={highlightedNumber}
           pencilMarkBoard={pencilMarkBoard}
         />
-        {isPaused === true && (
+        {isPaused && (
           <div className="game-board__paused-overlay">Paused</div>
         )}
         {validationStatus === ServerBoardValidationStatus.SOLVED && (

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -21,6 +21,8 @@ import { Dispatch } from "redux"
 import BoardLines from "./BoardLines/BoardLines"
 import "./GameBoard.css"
 import ParsedBoard from "./ParsedBoard/ParsedBoard"
+import { selectGameIsPaused } from "governor/game"
+
 export interface GameBoardProps {
   board: Board
   validationStatus: ServerBoardValidationStatus
@@ -28,6 +30,7 @@ export interface GameBoardProps {
   highlightedNumber: number
   pencilMarkBoard: PencilMarkBoard
   isPencilMode: boolean
+  isPaused: boolean
 
   fetchBoard: () => {}
   setUserPressed: Function
@@ -41,6 +44,7 @@ const GameBoard: FC<GameBoardProps> = ({
   highlightedNumber,
   pencilMarkBoard,
   setUserPressed,
+  isPaused,
 }) => {
   useEffect(() => {
     // if the board is empty, or if it's not empty and every piece contains a 0.
@@ -79,6 +83,9 @@ const GameBoard: FC<GameBoardProps> = ({
           highlightedNumber={highlightedNumber}
           pencilMarkBoard={pencilMarkBoard}
         />
+        {isPaused === true && (
+          <div className="game-board__paused-overlay">Paused</div>
+        )}
         {validationStatus === ServerBoardValidationStatus.SOLVED && (
           <div className="game-board__success-overlay">Awesome!</div>
         )}
@@ -94,6 +101,7 @@ const mapStateToProps = (state: InitialState) => ({
   highlightedNumber: selectHighlightedNumber(state),
   pencilMarkBoard: selectPencilMarkBoard(state),
   isPencilMode: selectIsPencilMode(state),
+  isPaused: selectGameIsPaused(state),
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -84,7 +84,15 @@ const GameBoard: FC<GameBoardProps> = ({
           pencilMarkBoard={pencilMarkBoard}
         />
         {isPaused && (
-          <div className="game-board__paused-overlay">Paused</div>
+          <div className="empty-board">
+            <BoardLines />
+            {board?.map(() =>
+              <div className="empty-piece"/>
+            )}
+            <div className="game-board__paused-overlay">
+              PAUSE
+            </div>
+          </div>
         )}
         {validationStatus === ServerBoardValidationStatus.SOLVED && (
           <div className="game-board__success-overlay">Awesome!</div>

--- a/src/components/GameBoard/Piece/Piece.tsx
+++ b/src/components/GameBoard/Piece/Piece.tsx
@@ -61,7 +61,7 @@ const Piece: FC<PieceProps> = ({
             isActive={isActive}
           ></PencilGrid>
         )}
-        {number === 0 ? "" : `${number}`}
+        {number === 0 ? "" : number}
       </div>
     </>
   )
@@ -73,4 +73,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(createBoardSetHighlightedNumber(number)),
 })
 
-export default connect(mapDispatchToProps)(Piece)
+export default connect(null, mapDispatchToProps)(Piece)

--- a/src/components/GameBoard/Piece/Piece.tsx
+++ b/src/components/GameBoard/Piece/Piece.tsx
@@ -8,8 +8,6 @@ import {
 } from "../../../governor/board"
 import PencilGrid from "./PencilGrid/PencilGrid"
 import "./Piece.css"
-import { InitialState } from "governor/initialState"
-import { selectGameIsPaused } from "governor/game"
 
 export interface PieceProps {
   number: number
@@ -19,7 +17,6 @@ export interface PieceProps {
   isWrong: boolean
   isHighlighted: boolean
   pencilMarks: number[]
-  isPaused: boolean
 
   onPieceClick: (num?: number) => {}
   setHighlightedNumber: (num?: number) => {}
@@ -35,7 +32,6 @@ const Piece: FC<PieceProps> = ({
   onPieceClick,
   setHighlightedNumber,
   pencilMarks,
-  isPaused,
 }) => {
   const _classNames = classnames("piece", {
     "piece--active": isActive,
@@ -65,15 +61,11 @@ const Piece: FC<PieceProps> = ({
             isActive={isActive}
           ></PencilGrid>
         )}
-        {number === 0 ? "" : isPaused ? "" : `${number}`}
+        {number === 0 ? "" : `${number}`}
       </div>
     </>
   )
 }
-
-const mapStateToProps = (state: InitialState) => ({
-  isPaused: selectGameIsPaused(state),
-})
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   onPieceClick: index => dispatch(createBoardSelectPieceAction(index)),
@@ -81,4 +73,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(createBoardSetHighlightedNumber(number)),
 })
 
-export default connect(mapStateToProps, mapDispatchToProps)(Piece)
+export default connect(mapDispatchToProps)(Piece)


### PR DESCRIPTION
I sent some messages to you and Honjae about how we want to make the paused game to look. I did the quicker easier option first just to give us something to work with but yeah I'm pretty sure I didn't follow proper coding convention for some things so just let me know. I pretty much just made it the same as the overlay for finishing the game except not as dark and more blurry so people can't cheat.
- Made it to where pieces aren't tracking the paused state
- Add an overlay when paused
<img width="1440" alt="paused game" src="https://user-images.githubusercontent.com/65873888/95930490-358dcc80-0d8c-11eb-9997-b1bd28c4fb89.png">
